### PR TITLE
op3: fix OTA auto-flashing with encrypted f2fs.

### DIFF
--- a/sepolicy/system_server.te
+++ b/sepolicy/system_server.te
@@ -1,1 +1,4 @@
 get_prop(system_server, vendor_camera_prop)
+
+# OTA with encrypted f2fs
+allow system_server ota_package_file:dir getattr;

--- a/sepolicy/uncrypt.te
+++ b/sepolicy/uncrypt.te
@@ -1,0 +1,2 @@
+# OTA with encrypted f2fs
+allow uncrypt self:capability fowner;


### PR DESCRIPTION
  If userdata is on f2fs and encrypted (OOS stock config for userdata),
  neither /cache/recovery/block.map, nor /cache/recovery/uncrypt_file
  are created due to theses denials:

  03-12 11:14:40.568  1290  1290 W Thread-26: type=1400 audit(0.0:176): avc: denied { getattr } for path="/data/lineageos_updates" dev="dm-0" ino=25753 scontext=u:r:system_server:s0 tcontext=u:object_r:ota_package_file:s0 tclass=dir permissive=0
  03-12 11:14:41.575  6803  6803 W uncrypt : type=1400 audit(0.0:178): avc: denied { fowner } for capability=3 scontext=u:r:uncrypt:s0 tcontext=u:r:uncrypt:s0 tclass=capability permissive=0

  Without block.map and uncrypt_file the automatic flashing of the OTA
  without user interaction fails, and the user needs to manually mount
  data, and flash the OTA manually.

Change-Id: I6ecb84e8b730d4c641a8bd8769043dfbfb817b83